### PR TITLE
Implement forced workspace selection for new users and enhance landin…

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,12 +16,15 @@ import {
 import { EventDetailsModal } from "./components/modals/EventDetailsModal";
 import { Dashboard } from "./components/dashboard/Dashboard";
 import { Settings } from "./components/settings/Settings";
-import { fetchEvents, setTokenGetter, deleteEvent, fetchCurrentUser, type BackendEvent } from "./lib/api";
+import { fetchEvents, setTokenGetter, deleteEvent, fetchCurrentUser, createWorkspace, joinWorkspace, fetchAllUsers, fetchWorkspaceList, type BackendEvent, type User } from "./lib/api";
 import { parseISO as parseISOBase, addWeeks, isSameWeek, startOfWeek } from "date-fns";
 import Tasks from "./components/tasks/Tasks";
 import { Resources } from "./components/resources/Resources";
 import { MessageBoard } from "./components/messageboard/MessageBoard";
 import { LandingPage } from "./components/landing/LandingPage";
+import { Modal } from "./components/modals/Modal";
+import { WorkspaceActionModal } from "./components/modals/WorkspaceActionModal";
+import { JoinWorkspaceModal } from "./components/modals/JoinWorkspaceModal";
 
 type CalRoute =
   | "dashboard"
@@ -72,11 +75,90 @@ export default function App() {
   }, [isAuthenticated, getAccessTokenSilently]);
 
   // Route + workspace
-  const [current, setCurrent] = useState<CalRoute>("calendar");
+  const [current, setCurrent] = useState<CalRoute>("dashboard");
   const [workspace, setWorkspace] = useState<string>(() => {
     return localStorage.getItem("cd.workspace") || "";
   });
   useEffect(() => localStorage.setItem("cd.workspace", workspace), [workspace]);
+
+  // Forced workspace selection for new users
+  const [showForcedWorkspaceSelection, setShowForcedWorkspaceSelection] = useState(false);
+  const [showActionModal, setShowActionModal] = useState(false);
+  const [showCreate, setShowCreate] = useState(false);
+  const [showJoin, setShowJoin] = useState(false);
+  const [wsName, setWsName] = useState("");
+  const [wsDesc, setWsDesc] = useState("");
+  const [search, setSearch] = useState("");
+  const [selected, setSelected] = useState<User[]>([]);
+  const [users, setUsers] = useState<User[]>([]);
+  const [userWorkspaces, setUserWorkspaces] = useState<{ workspace_id: string; name: string }[]>([]);
+  const [workspacesLoaded, setWorkspacesLoaded] = useState(false);
+
+  // Fetch user's workspaces
+  useEffect(() => {
+    if (!isAuthenticated || !tokenReady) return;
+
+    const loadWorkspaces = async () => {
+      try {
+        const data = await fetchWorkspaceList();
+        setUserWorkspaces(data);
+        setWorkspacesLoaded(true);
+
+        // If user has no workspaces, force workspace selection
+        if (data.length === 0) {
+          setWorkspace("");
+          setShowForcedWorkspaceSelection(true);
+          setShowActionModal(true);
+        }
+        // If user has workspaces but none selected, auto-select first one
+        else if (!workspace || !data.some(w => w.workspace_id === workspace)) {
+          setWorkspace(data[0].workspace_id);
+        }
+      } catch (error) {
+        console.error("Failed to fetch workspaces:", error);
+        setWorkspacesLoaded(true);
+      }
+    };
+
+    loadWorkspaces();
+  }, [isAuthenticated, tokenReady]);
+
+  // Update forced selection state when workspace changes
+  useEffect(() => {
+    if (!workspacesLoaded) return;
+
+    if (userWorkspaces.length === 0 || !workspace) {
+      setShowForcedWorkspaceSelection(true);
+    } else {
+      setShowForcedWorkspaceSelection(false);
+    }
+  }, [workspace, userWorkspaces, workspacesLoaded]);
+
+  // Fetch all users for member selection
+  useEffect(() => {
+    if (!isAuthenticated || !tokenReady) return;
+
+    const loadUsers = async () => {
+      const MAX_RETRIES = 2;
+      const RETRY_DELAY = 1000;
+
+      for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+        try {
+          console.log(`Attempt ${attempt}: Fetching all users...`);
+          const data = await fetchAllUsers();
+          setUsers(data);
+          return;
+        } catch (error) {
+          console.error(`Attempt ${attempt} failed:`, error);
+          if (attempt < MAX_RETRIES) {
+            await new Promise((res) => setTimeout(res, RETRY_DELAY));
+          }
+        }
+      }
+    };
+
+    loadUsers();
+  }, [isAuthenticated, tokenReady]);
 
   // Scroll to top when route changes
   const mainContentRef = useRef<HTMLDivElement>(null);
@@ -248,6 +330,65 @@ export default function App() {
     setCurrent("dashboard");
   };
 
+  // Create workspace handler
+  const handleCreateWorkspace = async () => {
+    try {
+      const payload = {
+        name: wsName,
+        description: wsDesc,
+        members: [],
+      };
+      const newWorkspace = await createWorkspace(payload);
+      console.log("Workspace created:", newWorkspace);
+
+      // Refresh workspace list
+      const updatedWorkspaces = await fetchWorkspaceList();
+      setUserWorkspaces(updatedWorkspaces);
+
+      setShowCreate(false);
+      setShowActionModal(false);
+      setWorkspace(newWorkspace.workspace_id);
+      setWsName("");
+      setWsDesc("");
+      setSelected([]);
+    } catch (error) {
+      console.error("Error creating workspace:", error);
+      alert("Failed to create workspace. Please try again.");
+    }
+  };
+
+  // Join workspace handler
+  const handleJoinWorkspace = async (code: string) => {
+    try {
+      const joinedWorkspace = await joinWorkspace(code);
+      console.log("Joined workspace:", joinedWorkspace);
+
+      // Refresh workspace list
+      const updatedWorkspaces = await fetchWorkspaceList();
+      setUserWorkspaces(updatedWorkspaces);
+
+      setShowJoin(false);
+      setShowActionModal(false);
+      setWorkspace(joinedWorkspace.workspace_id);
+    } catch (error) {
+      console.error("Error joining workspace:", error);
+      alert("Failed to join workspace. Please check the code and try again.");
+    }
+  };
+
+  // User selection helpers
+  const filtered = users.filter((u) =>
+    u.full_name.toLowerCase().includes(search.toLowerCase())
+  );
+
+  const toggleSelect = (user: User) => {
+    setSelected((prev) =>
+      prev.some((s) => s.id === user.id)
+        ? prev.filter((s) => s.id !== user.id)
+        : [...prev, user]
+    );
+  };
+
   // Show loading screen while Auth0 initializes
   if (isLoading) {
     return (
@@ -267,8 +408,11 @@ export default function App() {
   // Show main app if authenticated
   return (
     <div className="min-h-screen bg-zinc-50 text-zinc-900 dark:bg-zinc-950 dark:text-zinc-100">
-      {/* TopBar */}
-      <TopBar workspaceName={workspace} onWorkspace={setWorkspace} />
+      {/* Show main app only if workspace is selected */}
+      {!showForcedWorkspaceSelection && (
+        <>
+          {/* TopBar */}
+          <TopBar workspaceName={workspace} onWorkspace={setWorkspace} />
 
       <div className="w-full h-full flex px-6 py-4 gap-6">
         {/* Sidebar */}
@@ -376,6 +520,108 @@ export default function App() {
         currentUserId={currentUserId}
         onDelete={handleDeleteEvent}
       />
+        </>
+      )}
+
+      {/* Forced workspace selection modals for new users */}
+      {showForcedWorkspaceSelection && (
+        <>
+          {/* Workspace Action Selection Modal - cannot be closed */}
+          <WorkspaceActionModal
+            open={showActionModal}
+            onClose={() => {}} // Cannot close - must select an option
+            onCreateWorkspace={() => {
+              setShowActionModal(false);
+              setShowCreate(true);
+            }}
+            onJoinWorkspace={() => {
+              setShowActionModal(false);
+              setShowJoin(true);
+            }}
+          />
+
+          {/* Create Workspace Modal */}
+          <Modal
+            open={showCreate}
+            onClose={() => {
+              setShowCreate(false);
+              setShowActionModal(true); // Go back to action modal
+            }}
+            title="Create New Workspace"
+          >
+            <div className="space-y-4 p-1">
+              <div>
+                <label className="text-sm font-medium">Workspace Name</label>
+                <input
+                  type="text"
+                  value={wsName}
+                  onChange={(e) => setWsName(e.target.value)}
+                  placeholder="e.g. Marketing Team"
+                  className="mt-1 w-full rounded-md border border-zinc-300 dark:border-zinc-700 bg-transparent px-3 py-2 text-sm"
+                />
+              </div>
+
+              <div>
+                <label className="text-sm font-medium">Description</label>
+                <textarea
+                  value={wsDesc}
+                  onChange={(e) => setWsDesc(e.target.value)}
+                  placeholder="Briefly describe this workspace"
+                  className="mt-1 w-full rounded-md border border-zinc-300 dark:border-zinc-700 bg-transparent px-3 py-2 text-sm"
+                />
+              </div>
+
+              <div>
+                <label className="text-sm font-medium">Add Members (Optional)</label>
+                <input
+                  type="text"
+                  value={search}
+                  onChange={(e) => setSearch(e.target.value)}
+                  placeholder="Search by name"
+                  className="mt-1 w-full rounded-md border border-zinc-300 dark:border-zinc-700 bg-transparent px-3 py-2 text-sm"
+                />
+                <div className="mt-2 max-h-32 overflow-y-auto border border-zinc-200 dark:border-zinc-700 rounded-md">
+                  {filtered.map((user) => {
+                    const selectedUser = selected.some((s) => s.id === user.id);
+                    return (
+                      <button
+                        key={user.user_id}
+                        onClick={() => toggleSelect(user)}
+                        className={`w-full text-left px-3 py-2 text-sm rounded-md transition-colors duration-150 ${
+                          selectedUser
+                            ? "bg-blue-100 text-blue-800 dark:bg-blue-900/60 dark:text-blue-300"
+                            : "hover:bg-zinc-100 dark:hover:bg-zinc-800 text-zinc-900 dark:text-zinc-100"
+                        }`}
+                      >
+                        <span className="font-medium">{user.full_name}</span>
+                        <span className="text-xs text-gray-500 ml-2">{user.email}</span>
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+
+              <button
+                onClick={handleCreateWorkspace}
+                disabled={!wsName.trim()}
+                className="w-full rounded-md bg-zinc-900 dark:bg-zinc-100 text-white dark:text-black py-2 text-sm font-medium hover:opacity-90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                Create Workspace
+              </button>
+            </div>
+          </Modal>
+
+          {/* Join Workspace Modal */}
+          <JoinWorkspaceModal
+            open={showJoin}
+            onClose={() => {
+              setShowJoin(false);
+              setShowActionModal(true); // Go back to action modal
+            }}
+            onJoin={handleJoinWorkspace}
+          />
+        </>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
 New User Flow:
  - Force new users to create or join a workspace before accessing the app
  - Fetch user's workspace list on authentication
  - Auto-select first workspace if user has workspaces but none selected
  - Show modal that cannot be dismissed until workspace is selected
  - Hide entire app UI (TopBar, Sidebar, content) until workspace selected
  - Refresh workspace list after creating or joining a workspace

  Landing Page Enhancements:
  - Change to dark gradient background (zinc-950 → zinc-900 → black)
  - Add animated gradient orbs with blur effects
  - Add floating geometric shapes with rotation animations
  - Add pulsing particle dots throughout the background
  - Add continuously scrolling grid pattern
  - Add animated gradient effect to hero text
  - Add glass-morphism effect to feature cards with backdrop blur
  - Improve button with glow effects and shadows
  - Set default route to dashboard instead of calendar