### PR TITLE
Fix calendar multi-day events and color scheme

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -488,6 +488,7 @@ export default function App() {
             onEventClick={handleEventClick}
             calendarView={calendarView}
             onViewChange={setCalendarView}
+            currentUserId={currentUserId}
           />
         ) : null}
       </div>

--- a/frontend/src/components/calendar/Agenda.tsx
+++ b/frontend/src/components/calendar/Agenda.tsx
@@ -1,17 +1,19 @@
 import { format, compareAsc } from "date-fns";
 
-export type CalEvent = { id: string; title: string; start: Date; end: Date; kind?: "meeting" | "unavailable" };
+export type CalEvent = { id: string; title: string; start: Date; end: Date; kind?: "meeting" | "unavailable"; createdBy?: number; };
 
 export function Agenda({
   events,
   onEventClick,
   calendarView,
   onViewChange,
+  currentUserId,
 }: {
   events: CalEvent[];
   onEventClick?: (id: string) => void;
   calendarView: "my" | "all";
   onViewChange: (view: "my" | "all") => void;
+  currentUserId?: number;
 }) {
   const sorted = [...events].sort((a, b) => compareAsc(a.start, b.start));
   return (
@@ -48,17 +50,36 @@ export function Agenda({
           )}
           {sorted.map((e) => {
             const isUnavailable = e.kind === "unavailable";
-            const borderColor = isUnavailable
-              ? "border-zinc-300 bg-zinc-100/50 dark:border-zinc-700 dark:bg-zinc-800/30"
-              : "border-zinc-200 dark:border-zinc-800";
+            const isOwnEvent = currentUserId !== undefined && e.createdBy === currentUserId;
+
+            // Color scheme based on ownership and type - matching CalendarWeek
+            const borderColor = isOwnEvent
+              ? (isUnavailable
+                  ? "border-zinc-300 bg-zinc-50/50 dark:border-zinc-500 dark:bg-zinc-900/30"
+                  : "border-[#E30B5D] bg-[#E30B5D]/20 dark:border-[#E30B5D] dark:bg-[#E30B5D]/20")
+              : (isUnavailable
+                  ? "border-gray-600 bg-gray-200/60 dark:border-gray-700 dark:bg-gray-950/60"
+                  : "border-[#4169E1] bg-[#4169E1]/20 dark:border-[#4169E1] dark:bg-[#4169E1]/20");
+
+            const leftBorderColor = isUnavailable
+              ? (isOwnEvent
+                  ? "border-l-4 border-l-zinc-400 dark:border-l-zinc-400"
+                  : "border-l-4 border-l-gray-700 dark:border-l-gray-600")
+              : "";
+
+            const hoverColor = isOwnEvent
+              ? (isUnavailable
+                  ? "hover:bg-zinc-100/60 dark:hover:bg-zinc-900/50"
+                  : "hover:bg-[#E30B5D]/30 dark:hover:bg-[#E30B5D]/30")
+              : (isUnavailable
+                  ? "hover:bg-gray-300/60 dark:hover:bg-gray-950/70"
+                  : "hover:bg-[#4169E1]/30 dark:hover:bg-[#4169E1]/30");
 
             return (
               <button
                 key={e.id}
                 onClick={() => onEventClick?.(e.id)}
-                className={`w-full text-left rounded-xl border p-2 ${borderColor} ${
-                  isUnavailable ? "border-l-4 border-l-zinc-500 dark:border-l-zinc-600" : ""
-                } hover:bg-zinc-50 dark:hover:bg-zinc-800/50 transition-colors cursor-pointer`}
+                className={`w-full text-left rounded-xl border p-2 ${borderColor} ${leftBorderColor} ${hoverColor} transition-colors cursor-pointer`}
                 title={`${e.title} • ${format(e.start, "EEE p")}–${format(e.end, "p")}`}
               >
                 <div className="font-medium">

--- a/frontend/src/components/calendar/CalendarWeek.tsx
+++ b/frontend/src/components/calendar/CalendarWeek.tsx
@@ -15,8 +15,13 @@ import {
     createdBy?: number;
   };
   
-  const HOURS = Array.from({ length: 15 }, (_, i) => i + 6); // 06–20
-  
+  const HOURS = Array.from({ length: 24 }, (_, i) => i); // 00–23 (full day)
+
+  // Helper function to detect if two events overlap
+  function eventsOverlap(e1: CalendarEvent, e2: CalendarEvent): boolean {
+    return e1.start < e2.end && e2.start < e1.end;
+  }
+
   export function CalendarWeek({
     weekStart,
     events,
@@ -66,7 +71,7 @@ import {
                 key={h}
                 className="h-16 select-none px-2 text-[11px] leading-[4rem] text-zinc-400"
               >
-                {h <= 12 ? `${h} AM` : `${h - 12} PM`}
+                {h === 0 ? "12 AM" : h <= 11 ? `${h} AM` : h === 12 ? "12 PM" : `${h - 12} PM`}
               </div>
             ))}
           </div>
@@ -101,64 +106,234 @@ import {
           )}
   
           {/* Events */}
-          {events.map((e) => {
-            const dayIdx = differenceInCalendarDays(e.start, weekStart);
-            if (dayIdx < 0 || dayIdx > 6) return null;
-  
-            const startFrac = e.start.getHours() + e.start.getMinutes() / 60 - HOURS[0];
-            const endFrac = e.end.getHours() + e.end.getMinutes() / 60 - HOURS[0];
-            const top = startFrac * pxPerHour;
-            const height = Math.max(16, (endFrac - startFrac) * pxPerHour);
-  
-            const left = (dayIdx + 1) * dayColWidthPct;
-            const width = dayColWidthPct - 0.5;
-  
-            const isUnavailable = e.kind === "unavailable";
-            const isOwnEvent = currentUserId !== undefined && e.createdBy === currentUserId;
+          {/* Sort events: OOO first (render behind), then meetings */}
+          {[...events].sort((a, b) => {
+            // OOO events render first (will appear behind)
+            if (a.kind === "unavailable" && b.kind !== "unavailable") return -1;
+            if (a.kind !== "unavailable" && b.kind === "unavailable") return 1;
+            // Within same type, sort by start time
+            return a.start.getTime() - b.start.getTime();
+          }).flatMap((event) => {
+            // Check if event spans multiple days
+            const eventStartDay = differenceInCalendarDays(event.start, weekStart);
+            const eventEndDay = differenceInCalendarDays(event.end, weekStart);
 
-            // Color scheme based on ownership and type
-            const baseColor = isOwnEvent
-              ? (isUnavailable
-                  ? "border-zinc-300 bg-zinc-200/70 dark:border-zinc-700 dark:bg-zinc-800/60"
-                  : "border-blue-200 bg-blue-100/70 dark:border-blue-900/60 dark:bg-blue-900/40")
-              : (isUnavailable
-                  ? "border-emerald-300 bg-emerald-200/50 dark:border-emerald-700 dark:bg-emerald-800/40"
-                  : "border-emerald-200 bg-emerald-100/70 dark:border-emerald-900/60 dark:bg-emerald-900/40");
+            // Skip events outside the visible week
+            if (eventEndDay < 0 || eventStartDay >= 7) return [];
 
-            const hoverColor = isOwnEvent
-              ? (isUnavailable
-                  ? "hover:ring-2 hover:ring-zinc-400/60 dark:hover:ring-zinc-600/40"
-                  : "hover:ring-2 hover:ring-blue-300/60 dark:hover:ring-blue-600/40")
-              : (isUnavailable
-                  ? "hover:ring-2 hover:ring-emerald-400/60 dark:hover:ring-emerald-600/40"
-                  : "hover:ring-2 hover:ring-emerald-300/60 dark:hover:ring-emerald-600/40");
+            // Determine if this is a multi-day event
+            const isMultiDay = eventStartDay !== eventEndDay;
 
-            return (
-              <button
-                key={e.id}
-                onClick={() => onEventClick?.(e.id)}
-                className={`absolute overflow-hidden rounded-xl p-2 text-xs text-left transition focus:outline-none ${baseColor} ${hoverColor} ${
-                  isUnavailable ? (isOwnEvent ? "border-l-4 border-l-zinc-500 dark:border-l-zinc-600" : "border-l-4 border-l-emerald-500 dark:border-l-emerald-600") : ""
-                }`}
-                style={{
-                  top,
-                  left: `calc(${left}% + 0.25rem)`,
-                  width: `calc(${width}% - 0.5rem)`,
-                  height,
-                  backgroundImage: isUnavailable
-                    ? "repeating-linear-gradient(45deg, transparent, transparent 8px, rgba(113, 113, 122, 0.15) 8px, rgba(113, 113, 122, 0.15) 16px)"
-                    : undefined,
-                }}
-                title={`${e.title} • ${format(e.start, "EEE p")}–${format(e.end, "p")}`}
-              >
-                <div className="font-medium">
-                  {e.title}
-                </div>
-                <div className="mt-0.5 opacity-70">
-                  {format(e.start, "p")} – {format(e.end, "p")}
-                </div>
-              </button>
-            );
+            if (!isMultiDay) {
+              // Single-day event: render once
+              const dayIdx = eventStartDay;
+              if (dayIdx < 0 || dayIdx > 6) return [];
+  
+              const e = event; // For single-day event, use as-is
+              const startFrac = e.start.getHours() + e.start.getMinutes() / 60 - HOURS[0];
+              const endFrac = e.end.getHours() + e.end.getMinutes() / 60 - HOURS[0];
+              const top = startFrac * pxPerHour;
+              const height = Math.max(40, (endFrac - startFrac) * pxPerHour);
+
+              // Detect overlapping events in the same day
+              const sortedEvents = [...events].sort((a, b) => {
+                if (a.kind === "unavailable" && b.kind !== "unavailable") return -1;
+                if (a.kind !== "unavailable" && b.kind === "unavailable") return 1;
+                return a.start.getTime() - b.start.getTime();
+              });
+
+              // Find events that SPAN this day (not just start on it)
+              const dayEvents = sortedEvents.filter(ev => {
+                const evStartDay = differenceInCalendarDays(ev.start, weekStart);
+                const evEndDay = differenceInCalendarDays(ev.end, weekStart);
+                // Include events that start on or before this day AND end on or after this day
+                return evStartDay <= dayIdx && evEndDay >= dayIdx;
+              });
+
+              // Only consider overlaps with events of the same type
+              // Events share space with events, OOO shares space with OOO
+              const overlappingEvents = dayEvents.filter(ev =>
+                eventsOverlap(ev, e) && ev.kind === e.kind
+              );
+
+              // Calculate width and position based on overlaps
+              const totalOverlapping = Math.min(overlappingEvents.length, 4); // Max 4 columns
+              const eventIndex = overlappingEvents.findIndex(oe => oe.id === e.id);
+
+              const baseLeft = (dayIdx + 1) * dayColWidthPct;
+              const adjustedWidth = (dayColWidthPct - 0.5) / totalOverlapping;
+              const left = baseLeft + (adjustedWidth * eventIndex);
+              const width = adjustedWidth;
+
+              const isUnavailable = e.kind === "unavailable";
+              const isOwnEvent = currentUserId !== undefined && e.createdBy === currentUserId;
+
+              // Color scheme based on ownership and type
+              const baseColor = isOwnEvent
+                ? (isUnavailable
+                    ? "border-zinc-300 bg-zinc-50/60 dark:border-zinc-500 dark:bg-zinc-900/40"
+                    : "border-[#E30B5D] bg-[#E30B5D]/50 dark:border-[#E30B5D] dark:bg-[#E30B5D]/50")
+                : (isUnavailable
+                    ? "border-gray-600 bg-gray-200/70 dark:border-gray-700 dark:bg-gray-950/70"
+                    : "border-[#4169E1] bg-[#4169E1]/50 dark:border-[#4169E1] dark:bg-[#4169E1]/50");
+
+              const hoverColor = isOwnEvent
+                ? (isUnavailable
+                    ? "hover:ring-2 hover:ring-zinc-400/60 dark:hover:ring-zinc-400/40"
+                    : "hover:ring-2 hover:ring-[#E30B5D]/60 dark:hover:ring-[#E30B5D]/60")
+                : (isUnavailable
+                    ? "hover:ring-2 hover:ring-gray-600/60 dark:hover:ring-gray-600/40"
+                    : "hover:ring-2 hover:ring-[#4169E1]/60 dark:hover:ring-[#4169E1]/60");
+
+              return [
+                <button
+                  key={e.id}
+                  onClick={() => onEventClick?.(e.id)}
+                  className={`absolute overflow-hidden rounded-xl p-2 text-xs text-left transition focus:outline-none ${baseColor} ${hoverColor} ${
+                    isUnavailable ? (isOwnEvent ? "border-l-4 border-l-zinc-400 dark:border-l-zinc-400" : "border-l-4 border-l-gray-700 dark:border-l-gray-600") : ""
+                  }`}
+                  style={{
+                    top,
+                    left: `calc(${left}% + 0.25rem)`,
+                    width: `calc(${width}% - 0.5rem)`,
+                    height,
+                    zIndex: isUnavailable ? 0 : 10,
+                    backgroundImage: isUnavailable
+                      ? (isOwnEvent
+                          ? "repeating-linear-gradient(45deg, transparent, transparent 8px, rgba(113, 113, 122, 0.12) 8px, rgba(113, 113, 122, 0.12) 16px)"
+                          : "repeating-linear-gradient(45deg, transparent, transparent 8px, rgba(55, 65, 81, 0.2) 8px, rgba(55, 65, 81, 0.2) 16px)")
+                      : undefined,
+                  }}
+                  title={`${e.title} • ${format(e.start, "EEE p")}–${format(e.end, "p")}`}
+                >
+                  <div className="font-medium truncate">
+                    {e.title}
+                  </div>
+                  {height >= 50 && (
+                    <div className="mt-0.5 opacity-70 truncate">
+                      {format(e.start, "p")} – {format(e.end, "p")}
+                    </div>
+                  )}
+                </button>
+              ];
+            } else {
+              // Multi-day event: create segments for each day
+              const firstVisibleDay = Math.max(0, eventStartDay);
+              const lastVisibleDay = Math.min(6, eventEndDay);
+
+              const segments = [];
+              for (let dayOffset = firstVisibleDay; dayOffset <= lastVisibleDay; dayOffset++) {
+                const dayIdx = dayOffset;
+                const segmentDate = new Date(weekStart);
+                segmentDate.setDate(weekStart.getDate() + dayOffset);
+
+                const dayStartTime = new Date(segmentDate);
+                dayStartTime.setHours(0, 0, 0, 0);
+
+                const dayEndTime = new Date(segmentDate);
+                dayEndTime.setHours(23, 59, 59, 999);
+
+                // Determine segment start and end
+                const segmentStart = dayOffset === eventStartDay ? event.start : dayStartTime;
+                const segmentEnd = dayOffset === eventEndDay ? event.end : dayEndTime;
+
+                // Create a segment event object
+                const e = {
+                  ...event,
+                  id: `${event.id}__seg_${dayOffset}`,
+                  start: segmentStart,
+                  end: segmentEnd,
+                };
+
+                const startFrac = segmentStart.getHours() + segmentStart.getMinutes() / 60 - HOURS[0];
+                const endFrac = segmentEnd.getHours() + segmentEnd.getMinutes() / 60 - HOURS[0];
+                const top = startFrac * pxPerHour;
+                const height = Math.max(40, (endFrac - startFrac) * pxPerHour);
+
+                // Detect overlapping events in the same day
+                const sortedEvents = [...events].sort((a, b) => {
+                  if (a.kind === "unavailable" && b.kind !== "unavailable") return -1;
+                  if (a.kind !== "unavailable" && b.kind === "unavailable") return 1;
+                  return a.start.getTime() - b.start.getTime();
+                });
+
+                // For multi-day segments, we need to find events that SPAN this day, not just START on it
+                const dayEvents = sortedEvents.filter(ev => {
+                  const evStartDay = differenceInCalendarDays(ev.start, weekStart);
+                  const evEndDay = differenceInCalendarDays(ev.end, weekStart);
+                  // Include events that start on or before this day AND end on or after this day
+                  return evStartDay <= dayIdx && evEndDay >= dayIdx;
+                });
+
+                // Only consider overlaps with events of the same type
+                const overlappingEvents = dayEvents.filter(ev =>
+                  eventsOverlap(ev, e) && ev.kind === e.kind
+                );
+
+                // Calculate width and position based on overlaps
+                const totalOverlapping = Math.min(overlappingEvents.length, 4);
+                const eventIndex = overlappingEvents.findIndex(oe => oe.id === e.id || oe.id.startsWith(event.id));
+
+                const baseLeft = (dayIdx + 1) * dayColWidthPct;
+                const adjustedWidth = (dayColWidthPct - 0.5) / totalOverlapping;
+                const left = baseLeft + (adjustedWidth * eventIndex);
+                const width = adjustedWidth;
+
+                const isUnavailable = e.kind === "unavailable";
+                const isOwnEvent = currentUserId !== undefined && e.createdBy === currentUserId;
+
+                // Color scheme based on ownership and type
+                const baseColor = isOwnEvent
+                  ? (isUnavailable
+                      ? "border-zinc-300 bg-zinc-50/60 dark:border-zinc-500 dark:bg-zinc-900/40"
+                      : "border-[#E30B5D] bg-[#E30B5D]/50 dark:border-[#E30B5D] dark:bg-[#E30B5D]/50")
+                  : (isUnavailable
+                      ? "border-gray-600 bg-gray-200/70 dark:border-gray-700 dark:bg-gray-950/70"
+                      : "border-[#4169E1] bg-[#4169E1]/50 dark:border-[#4169E1] dark:bg-[#4169E1]/50");
+
+                const hoverColor = isOwnEvent
+                  ? (isUnavailable
+                      ? "hover:ring-2 hover:ring-zinc-400/60 dark:hover:ring-zinc-400/40"
+                      : "hover:ring-2 hover:ring-[#E30B5D]/60 dark:hover:ring-[#E30B5D]/60")
+                  : (isUnavailable
+                      ? "hover:ring-2 hover:ring-gray-600/60 dark:hover:ring-gray-600/40"
+                      : "hover:ring-2 hover:ring-[#4169E1]/60 dark:hover:ring-[#4169E1]/60");
+
+                segments.push(
+                  <button
+                    key={e.id}
+                    onClick={() => onEventClick?.(event.id)} // Use original event ID for click handler
+                    className={`absolute overflow-hidden rounded-xl p-2 text-xs text-left transition focus:outline-none ${baseColor} ${hoverColor} ${
+                      isUnavailable ? (isOwnEvent ? "border-l-4 border-l-zinc-400 dark:border-l-zinc-400" : "border-l-4 border-l-gray-700 dark:border-l-gray-600") : ""
+                    }`}
+                    style={{
+                      top,
+                      left: `calc(${left}% + 0.25rem)`,
+                      width: `calc(${width}% - 0.5rem)`,
+                      height,
+                      zIndex: isUnavailable ? 0 : 10,
+                      backgroundImage: isUnavailable
+                        ? (isOwnEvent
+                            ? "repeating-linear-gradient(45deg, transparent, transparent 8px, rgba(113, 113, 122, 0.12) 8px, rgba(113, 113, 122, 0.12) 16px)"
+                            : "repeating-linear-gradient(45deg, transparent, transparent 8px, rgba(55, 65, 81, 0.2) 8px, rgba(55, 65, 81, 0.2) 16px)")
+                        : undefined,
+                    }}
+                    title={`${event.title} • ${format(event.start, "EEE p")}–${format(event.end, "p")}`}
+                  >
+                    <div className="font-medium truncate">
+                      {event.title}
+                    </div>
+                    {height >= 50 && (
+                      <div className="mt-0.5 opacity-70 truncate">
+                        {format(segmentStart, "p")} – {format(segmentEnd, "p")}
+                      </div>
+                    )}
+                  </button>
+                );
+              }
+
+              return segments;
+            }
           })}
         </div>
       </div>

--- a/frontend/src/components/modals/EventDetailsModal.tsx
+++ b/frontend/src/components/modals/EventDetailsModal.tsx
@@ -54,9 +54,13 @@ export function EventDetailsModal({
           <div className="inline-flex items-center gap-2">
             <span
               className={`px-2 py-1 rounded text-xs font-medium ${
-                isUnavailable
-                  ? "bg-zinc-100 dark:bg-zinc-800 text-zinc-700 dark:text-zinc-300"
-                  : "bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300"
+                isMyEvent
+                  ? (isUnavailable
+                      ? "bg-zinc-100 dark:bg-zinc-800 text-zinc-600 dark:text-zinc-300"
+                      : "bg-[#E30B5D]/50 dark:bg-[#E30B5D]/50 text-[#E30B5D] dark:text-[#E30B5D]")
+                  : (isUnavailable
+                      ? "bg-gray-200 dark:bg-gray-800 text-gray-700 dark:text-gray-300"
+                      : "bg-[#4169E1]/50 dark:bg-[#4169E1]/50 text-[#4169E1] dark:text-[#4169E1]")
               }`}
             >
               {isUnavailable ? "Unavailable" : "Meeting"}


### PR DESCRIPTION
  - Expand calendar to full 24-hour day (00-23)
  - Implement inline multi-day event splitting
  - Fix overlap detection to find events spanning days (not just starting on days)
  - Fix positioning bug causing multi-day segments to render in hour gutter
  - Update color scheme: #E30B5D for personal events, #4169E1 for others
  - Ensure OOO blocks render behind meetings (z-index layering)
  - Events share space only with events, OOO only with OOO
  - Fix time display formatting for midnight and noon