### PR TITLE
Fix Resource Download and Display Issues

### DIFF
--- a/backend/collabdesk/resources/serializers.py
+++ b/backend/collabdesk/resources/serializers.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 class ResourceSerializer(serializers.ModelSerializer):
     workspace = serializers.PrimaryKeyRelatedField(read_only=True)
-    uploaded_by = serializers.PrimaryKeyRelatedField(read_only=True)
+    uploaded_by = serializers.SerializerMethodField(read_only=True)
     size = serializers.IntegerField(read_only=True)
     # Represent tags as a JSON list (accepts JSON string in multipart)
     tags = serializers.JSONField(required=False)
@@ -21,6 +21,12 @@ class ResourceSerializer(serializers.ModelSerializer):
         model = Resource
         fields = "__all__"
         read_only_fields = ["workspace", "size", "uploaded_by"]
+
+    def get_uploaded_by(self, obj):
+        """Return the full_name of the user who uploaded the resource."""
+        if obj.uploaded_by:
+            return obj.uploaded_by.full_name or obj.uploaded_by.username
+        return None
 
     def to_representation(self, instance):
         data = super().to_representation(instance)

--- a/backend/collabdesk/resources/urls.py
+++ b/backend/collabdesk/resources/urls.py
@@ -9,8 +9,13 @@ urlpatterns = [
     path("<uuid:pk>/", ResourceDetailView.as_view(), name="resource-detail"),
     path(
         "<uuid:pk>/download/",
-        ResourcePresignedUrlView.as_view(),
+        ResourceDownloadView.as_view(),
         name="resource-download",
+    ),
+    path(
+        "<uuid:pk>/preview/",
+        ResourcePreviewView.as_view(),
+        name="resource-preview",
     ),
     # Temporary function-based views (backup/alternative)
     path("upload/", views.upload_file, name="upload"),

--- a/backend/collabdesk/resources/views.py
+++ b/backend/collabdesk/resources/views.py
@@ -24,7 +24,9 @@ from .s3_utils import (
 # Create your views here.
 
 
-class ResourcePresignedUrlView(APIView):
+class ResourceDownloadView(APIView):
+    """Generate presigned URL for downloading (forces attachment)."""
+
     permission_classes = [IsAuthenticated]
 
     def get(self, request, pk):
@@ -43,9 +45,15 @@ class ResourcePresignedUrlView(APIView):
                 aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
                 region_name=settings.AWS_S3_REGION_NAME,
             )
+            # Extract original filename from the S3 key (remove UUID prefix)
+            filename = key.split("_", 1)[1] if "_" in key else key
             url = s3.generate_presigned_url(
                 ClientMethod="get_object",
-                Params={"Bucket": settings.AWS_STORAGE_BUCKET_NAME, "Key": key},
+                Params={
+                    "Bucket": settings.AWS_STORAGE_BUCKET_NAME,
+                    "Key": key,
+                    "ResponseContentDisposition": f'attachment; filename="{filename}"',
+                },
                 ExpiresIn=3600,
             )
             return Response({"url": url})
@@ -60,6 +68,52 @@ class ResourcePresignedUrlView(APIView):
 
         filename = os.path.basename(key)
         response = FileResponse(file_obj, as_attachment=True, filename=filename)
+        return response
+
+
+class ResourcePreviewView(APIView):
+    """Generate presigned URL for previewing (inline display in browser)."""
+
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request, pk):
+        try:
+            resource = Resource.objects.get(pk=pk)
+        except Resource.DoesNotExist:
+            return Response({"detail": "Not found"}, status=status.HTTP_404_NOT_FOUND)
+        key = resource.file.name
+
+        # If an S3 bucket is configured, generate a presigned S3 URL.
+        if getattr(settings, "AWS_STORAGE_BUCKET_NAME", None):
+            s3 = boto3.client(
+                "s3",
+                aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
+                aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
+                region_name=settings.AWS_S3_REGION_NAME,
+            )
+            # Extract original filename from the S3 key (remove UUID prefix)
+            filename = key.split("_", 1)[1] if "_" in key else key
+            url = s3.generate_presigned_url(
+                ClientMethod="get_object",
+                Params={
+                    "Bucket": settings.AWS_STORAGE_BUCKET_NAME,
+                    "Key": key,
+                    "ResponseContentDisposition": f'inline; filename="{filename}"',
+                },
+                ExpiresIn=3600,
+            )
+            return Response({"url": url})
+
+        # Otherwise assume local FileSystemStorage (local testing) and stream the file
+        # back to the client using FileResponse.
+        try:
+            file_obj = default_storage.open(key, "rb")
+        except Exception:
+            # Could not open the file from storage
+            raise Http404("File not found")
+
+        filename = os.path.basename(key)
+        response = FileResponse(file_obj, as_attachment=False, filename=filename)
         return response
 
 

--- a/frontend/src/components/resources/ResourceApi.ts
+++ b/frontend/src/components/resources/ResourceApi.ts
@@ -181,19 +181,7 @@ export const deleteResource = async (id: string): Promise<void> => {
 // Download a resource
 export const downloadResource = async (resource: Resource): Promise<void> => {
   try {
-    const blob = await apiDownloadResource(resource.id);
-    
-    // Create a temporary URL for the blob and trigger download
-    const url = window.URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = resource.fileName;
-    document.body.appendChild(a);
-    a.click();
-    
-    // Cleanup
-    window.URL.revokeObjectURL(url);
-    document.body.removeChild(a);
+    await apiDownloadResource(resource.id);
   } catch (error) {
     console.error('Failed to download resource:', error);
     throw error;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -506,7 +506,7 @@ export async function uploadResource(file: File, name: string, tags?: string[]):
   return response.json();
 }
 
-export async function downloadResource(resourceId: string): Promise<Blob> {
+export async function downloadResource(resourceId: string): Promise<void> {
   const response = await authenticatedFetch(`${API_BASE_URL}/api/resources/${resourceId}/download/`);
   
   if (!response.ok) {
@@ -519,17 +519,23 @@ export async function downloadResource(resourceId: string): Promise<Blob> {
     // S3 presigned URL response
     const data = await response.json();
     if (data.url) {
-      // Fetch from presigned URL
-      const fileResponse = await fetch(data.url);
-      if (!fileResponse.ok) {
-        throw new Error('Failed to download file from presigned URL');
-      }
-      return fileResponse.blob();
+      // Open presigned URL in new window to trigger download
+      // The ResponseContentDisposition header in the presigned URL will force download
+      window.open(data.url, '_blank');
+      return;
     }
   }
   
-  // Direct file download
-  return response.blob();
+  // Direct file download (local storage)
+  const blob = await response.blob();
+  const url = window.URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = 'download'; // Browser will use filename from Content-Disposition
+  document.body.appendChild(a);
+  a.click();
+  window.URL.revokeObjectURL(url);
+  document.body.removeChild(a);
 }
 
 export async function deleteResourceById(resourceId: string): Promise<void> {
@@ -548,7 +554,7 @@ export async function getResourcePreviewUrlById(resourceId: string): Promise<{
   url: string;
   revoke?: () => void;
 }> {
-  const response = await authenticatedFetch(`${API_BASE_URL}/api/resources/${resourceId}/download/`);
+  const response = await authenticatedFetch(`${API_BASE_URL}/api/resources/${resourceId}/preview/`);
 
   if (!response.ok) {
     const err = await response.text().catch(() => '');


### PR DESCRIPTION
### Problem Statement
When uploading files to S3, the application encountered a `FileNotFoundError` because Django's `FileSystemStorage` was trying to access file size from the local filesystem path `/var/app/current/media/<filename>`, even though files were stored in S3. Additionally:
- Download functionality failed with "Failed to download document" error
- The `uploaded_by` field displayed user IDs instead of names
- Preview and download used the same endpoint, preventing proper content disposition handling

### Root Cause
After uploading to S3, the serializer replaced the file field with an S3 key (string). When Django tried to access `FieldFile.size`, it called `os.path.getsize()` on a path constructed from `MEDIA_ROOT + S3_key`, which didn't exist locally.

### Changes Made

#### Backend Changes

1. **Fixed File Size Handling** (`resources/serializers.py`, `resources/models.py`)
   - Capture file size from in-memory uploaded file object before S3 upload
   - Set `validated_data['size']` directly in serializer's `create()` and `update()` methods
   - Modified `Resource.save()` to avoid calling `FieldFile.size` (which triggers storage lookup)
   - Now storage-agnostic: works with both S3 and local filesystem

2. **Separated Download and Preview Endpoints** (`resources/views.py`, `resources/urls.py`)
   - Created `ResourceDownloadView` at `/api/resources/<uuid>/download/`
     - Uses `ResponseContentDisposition: 'attachment'` to force browser download
   - Created `ResourcePreviewView` at `/api/resources/<uuid>/preview/`
     - Uses `ResponseContentDisposition: 'inline'` to allow in-browser preview
   - Both extract original filename from S3 key (removes UUID prefix)

3. **Display User Full Names** (`resources/serializers.py`)
   - Changed `uploaded_by` from `PrimaryKeyRelatedField` to `SerializerMethodField`
   - Returns `user.full_name` (or falls back to `username` if empty)
   - API now returns human-readable names instead of user IDs

#### Frontend Changes

1. **Updated API Layer** (`frontend/src/lib/api.ts`)
   - `downloadResource()` now calls `/download/` endpoint and uses `window.open()` to trigger download
   - `getResourcePreviewUrlById()` now calls `/preview/` endpoint
   - Simplified download flow: backend presigned URL handles download via Content-Disposition header

2. **Simplified Resource API** (`frontend/src/components/resources/ResourceApi.ts`)
   - Removed redundant blob handling from `downloadResource()`
   - Direct delegation to API layer