### PR TITLE
Quick fix for caching issue

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -82,7 +82,7 @@ export default function App() {
       }
     });
     setTokenReady(true);
-  }, [isAuthenticated, getAccessTokenSilently, logout, setTokenGetter]);
+  }, [isAuthenticated, getAccessTokenSilently, logout]);
 
   // Route + workspace
   const [current, setCurrent] = useState<CalRoute>("dashboard");


### PR DESCRIPTION
This is a quick workaround for the caching issue which forces a logout whenever the token expires. This way the user is expected to login again which generates a new token and preventing the stuck state.