### PR TITLE
Fixed bugs on Workspace and messages loading on dashboard

### DIFF
--- a/frontend/src/components/dashboard/Dashboard.tsx
+++ b/frontend/src/components/dashboard/Dashboard.tsx
@@ -11,7 +11,7 @@ export function Dashboard({
   workspaceId: string;
   onOpenMessageThread?: (messageId: string) => void;
 }) {
-  const { isAuthenticated, isLoading: authLoading } = useAuth0();
+  const { isAuthenticated, isLoading: authLoading, getAccessTokenSilently } = useAuth0();
   const [workspace, setWorkspace] = useState<Workspace | null>(null);
   const [currentUserId, setCurrentUserId] = useState<number | undefined>();
   const [loading, setLoading] = useState(true);
@@ -46,7 +46,9 @@ export function Dashboard({
     setLoading(true);
     setError("");
 
-    fetchWorkspaceInformation(workspaceId)
+    const tokenProvider = () => getAccessTokenSilently();
+
+    fetchWorkspaceInformation(workspaceId, tokenProvider)
       .then((data) => {
         setWorkspace(data);
       })
@@ -55,13 +57,14 @@ export function Dashboard({
         setError("Failed to load workspace.");
       })
       .finally(() => setLoading(false));
-  }, [workspaceId, isAuthenticated, authLoading]);
+  }, [workspaceId, isAuthenticated, authLoading, getAccessTokenSilently]);
 
   // Fetch recent messages
   useEffect(() => {
     const loadRecentMessages = async () => {
       try {
-        const messages = await getMessages();
+        const token = await getAccessTokenSilently();
+        const messages = await getMessages(token);
         // Get only parent messages, sort by timestamp descending, take latest 3
         const parentMessages = messages
           .filter((m) => m.parentId === null)
@@ -73,7 +76,7 @@ export function Dashboard({
       }
     };
     loadRecentMessages();
-  }, []);
+  }, [getAccessTokenSilently]);
 
   const handleWorkspaceUpdate = (updatedWorkspace: Workspace) => {
     setWorkspace(updatedWorkspace);

--- a/frontend/src/components/settings/Settings.tsx
+++ b/frontend/src/components/settings/Settings.tsx
@@ -11,7 +11,7 @@ export function Settings({
   workspaceId: string;
   onLeaveWorkspace: (id: string) => void;
 }) {
-  const { logout, isAuthenticated } = useAuth0();
+  const { logout, isAuthenticated, getAccessTokenSilently } = useAuth0();
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [notifications, setNotifications] = useState(true);
@@ -51,14 +51,15 @@ export function Settings({
 
     const loadWorkspaceData = async () => {
       try {
-        const workspaceData = await fetchWorkspaceInformation(workspaceId);
+        const tokenProvider = () => getAccessTokenSilently();
+        const workspaceData = await fetchWorkspaceInformation(workspaceId, tokenProvider);
         setWorkspace(workspaceData);
       } catch (error) {
         console.error("Failed to load workspace data:", error);
       }
     };
     loadWorkspaceData();
-  }, [isAuthenticated, workspaceId]);
+  }, [isAuthenticated, workspaceId, getAccessTokenSilently]);
 
   // Invite Code implementation
   const handleCopyInviteCode = () => {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -160,12 +160,23 @@ export async function fetchWorkspaceList(): Promise<WorkspaceListItem[]> {
   return response.json();
 }
 
+type TokenProvider = () => Promise<string>;
+
 export async function fetchWorkspaceInformation(
-  workspaceId: string
+  workspaceId: string,
+  tokenProvider: TokenProvider
 ): Promise<Workspace> {
-  const response = await authenticatedFetch(
-    `${API_BASE_URL}/api/workspaces/information/?workspace_id=${workspaceId}`
-  );
+  const token = await tokenProvider();
+
+  const url = `${API_BASE_URL}/api/workspaces/information/?workspace_id=${workspaceId}`;
+
+  const response = await fetch(url, {
+    method: 'GET',
+    headers: {
+      'Authorization': `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+  });
   if (!response.ok) {
     throw new Error('Failed to fetch workspace information');
   }


### PR DESCRIPTION
Fixed the following bugs:

**1. Failed to Load Workspace error (401/403)**

**Issue:** On initial load, the dashboard failed to fetch workspace data because a Bearer Access Token was missing from the API request headers. This was a race condition, the component initiated the fetch as soon as authentication was confirmed (isAuthenticated: true), but before the token was fully retrieved by Auth0. That was the reason it was working when we switched to a different resource and back, as the token was retrieved by then.

**Fix:** Modified the API utility to explicitly use await getAccessTokenSilently() before sending the request. This guarantees the inclusion of a valid, current Access Token in the Authorization header, resolving the race condition.

**2. Dashboard messages load failure (403)**

**Issue:** The API call to get messages also failed with a 403 Forbidden error because the request was sent without a valid Access Token. The getMessages() method expected an access token which was missing, hence we were getting the axios error.

**Fix:** We updated the request use the Access Token retrieved via getAccessTokenSilently(), thereby preventing unauthorized requests.