### PR TITLE
Configure nginx to accept 100MB files

### DIFF
--- a/backend/collabdesk/.platform/nginx/conf.d/proxy.conf
+++ b/backend/collabdesk/.platform/nginx/conf.d/proxy.conf
@@ -1,0 +1,1 @@
+client_max_body_size 100M;


### PR DESCRIPTION
I refered to the [AWS documentation](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/platforms-linux-extend.proxy.html) & [Solution](https://repost.aws/knowledge-center/elastic-beanstalk-nginx-configuration) to configure the nginx proxy. It's supposed to increase the file size limitation to 100MB.
