### PR TITLE
Ownership Feature

### DIFF
--- a/backend/collabdesk/collabdesk/permissions.py
+++ b/backend/collabdesk/collabdesk/permissions.py
@@ -212,9 +212,10 @@ class IsWorkspaceOwner(permissions.BasePermission):
             return False
 
         # If workspace_id is in URL kwargs, check ownership at view level
-        workspace_id = view.kwargs.get('workspace_id')
+        workspace_id = view.kwargs.get("workspace_id")
         if workspace_id:
             from workspaces.models import Workspace
+
             try:
                 workspace = Workspace.objects.get(workspace_id=workspace_id)
                 return workspace.created_by_id == request.user.id
@@ -237,11 +238,12 @@ class IsWorkspaceOwner(permissions.BasePermission):
 
         # If the object is a Workspace itself
         from workspaces.models import Workspace
+
         if isinstance(obj, Workspace):
             return obj.created_by_id == request.user.id
 
         # If the object has a workspace attribute
-        workspace = getattr(obj, 'workspace', None)
+        workspace = getattr(obj, "workspace", None)
         if workspace:
             return workspace.created_by_id == request.user.id
 
@@ -272,12 +274,12 @@ class IsEventCreatorOrWorkspaceOwner(permissions.BasePermission):
             return True
 
         # Check if user is the event creator
-        created_by = getattr(obj, 'created_by', None)
+        created_by = getattr(obj, "created_by", None)
         if created_by and created_by.id == request.user.id:
             return True
 
         # Check if user is the workspace owner
-        workspace = getattr(obj, 'workspace', None)
+        workspace = getattr(obj, "workspace", None)
         if workspace and workspace.created_by_id == request.user.id:
             return True
 
@@ -308,12 +310,12 @@ class IsResourceUploaderOrWorkspaceOwner(permissions.BasePermission):
             return True
 
         # Check if user is the resource uploader
-        uploaded_by = getattr(obj, 'uploaded_by', None)
+        uploaded_by = getattr(obj, "uploaded_by", None)
         if uploaded_by and uploaded_by.id == request.user.id:
             return True
 
         # Check if user is the workspace owner
-        workspace = getattr(obj, 'workspace', None)
+        workspace = getattr(obj, "workspace", None)
         if workspace and workspace.created_by_id == request.user.id:
             return True
 
@@ -344,16 +346,14 @@ class IsMessageAuthorOrWorkspaceOwnerDelete(permissions.BasePermission):
             return True
 
         # Check if user is the message author (full access)
-        author = getattr(obj, 'author', None)
+        author = getattr(obj, "author", None)
         if author and author.id == request.user.id:
             return True
 
         # Check if user is the workspace owner (DELETE only, not edit)
-        if request.method == 'DELETE':
-            workspace = getattr(obj, 'workspace', None)
+        if request.method == "DELETE":
+            workspace = getattr(obj, "workspace", None)
             if workspace and workspace.created_by_id == request.user.id:
                 return True
 
         return False
-
-

--- a/backend/collabdesk/collabdesk/permissions.py
+++ b/backend/collabdesk/collabdesk/permissions.py
@@ -320,3 +320,40 @@ class IsResourceUploaderOrWorkspaceOwner(permissions.BasePermission):
         return False
 
 
+class IsMessageAuthorOrWorkspaceOwnerDelete(permissions.BasePermission):
+    """
+    Permission class for messages that allows:
+    - All authenticated users: Read access (GET, HEAD, OPTIONS)
+    - Message author: Full access (GET, PUT, PATCH, DELETE)
+    - Workspace owner: DELETE only (not edit)
+    - Other users: Read-only access
+
+    Usage:
+        Add to permission_classes on message viewsets that need this behavior.
+    """
+
+    def has_object_permission(self, request, view, obj):
+        """
+        Check if user can perform the action on the message.
+        """
+        if not request.user or not request.user.is_authenticated:
+            return False
+
+        # Allow read-only access for all authenticated users
+        if request.method in permissions.SAFE_METHODS:
+            return True
+
+        # Check if user is the message author (full access)
+        author = getattr(obj, 'author', None)
+        if author and author.id == request.user.id:
+            return True
+
+        # Check if user is the workspace owner (DELETE only, not edit)
+        if request.method == 'DELETE':
+            workspace = getattr(obj, 'workspace', None)
+            if workspace and workspace.created_by_id == request.user.id:
+                return True
+
+        return False
+
+

--- a/backend/collabdesk/collabdesk/permissions.py
+++ b/backend/collabdesk/collabdesk/permissions.py
@@ -187,3 +187,100 @@ class IsAuthenticated(permissions.BasePermission):
         Return True if the request is authenticated via Auth0
         """
         return request.user and request.user.is_authenticated
+
+
+class IsWorkspaceOwner(permissions.BasePermission):
+    """
+    Permission class that checks if the user is the owner of the workspace.
+
+    This can be used for object-level permissions where the object has a
+    'workspace' attribute, or for view-level permissions where 'workspace_id'
+    is in the URL kwargs.
+
+    Usage:
+        - Add to permission_classes on any viewset that needs owner-only access
+        - Works with objects that have a 'workspace' foreign key
+        - Works with views that have 'workspace_id' in URL kwargs
+    """
+
+    def has_permission(self, request, view):
+        """
+        Check if user is authenticated and optionally check workspace ownership
+        at the view level when workspace_id is in URL kwargs.
+        """
+        if not request.user or not request.user.is_authenticated:
+            return False
+
+        # If workspace_id is in URL kwargs, check ownership at view level
+        workspace_id = view.kwargs.get('workspace_id')
+        if workspace_id:
+            from workspaces.models import Workspace
+            try:
+                workspace = Workspace.objects.get(workspace_id=workspace_id)
+                return workspace.created_by_id == request.user.id
+            except Workspace.DoesNotExist:
+                return False
+
+        # If no workspace_id in URL, defer to object-level permission
+        return True
+
+    def has_object_permission(self, request, view, obj):
+        """
+        Check if the user is the owner of the workspace associated with the object.
+
+        Supports objects that:
+        - Are a Workspace instance directly
+        - Have a 'workspace' attribute (ForeignKey to Workspace)
+        """
+        if not request.user or not request.user.is_authenticated:
+            return False
+
+        # If the object is a Workspace itself
+        from workspaces.models import Workspace
+        if isinstance(obj, Workspace):
+            return obj.created_by_id == request.user.id
+
+        # If the object has a workspace attribute
+        workspace = getattr(obj, 'workspace', None)
+        if workspace:
+            return workspace.created_by_id == request.user.id
+
+        return False
+
+
+class IsEventCreatorOrWorkspaceOwner(permissions.BasePermission):
+    """
+    Permission class for events that allows:
+    - All authenticated users: Read access (GET, HEAD, OPTIONS)
+    - Event creator: Full access (GET, POST, PUT, PATCH, DELETE)
+    - Workspace owner: Full access (GET, POST, PUT, PATCH, DELETE)
+    - Other users: Read-only access
+
+    Usage:
+        Add to permission_classes on event viewsets that need this behavior.
+    """
+
+    def has_object_permission(self, request, view, obj):
+        """
+        Check if user can perform the action on the event.
+        """
+        if not request.user or not request.user.is_authenticated:
+            return False
+
+        # Allow read-only access for all authenticated users
+        if request.method in permissions.SAFE_METHODS:
+            return True
+
+        # Check if user is the event creator
+        created_by = getattr(obj, 'created_by', None)
+        if created_by and created_by.id == request.user.id:
+            return True
+
+        # Check if user is the workspace owner
+        workspace = getattr(obj, 'workspace', None)
+        if workspace and workspace.created_by_id == request.user.id:
+            return True
+
+        return False
+
+

--- a/backend/collabdesk/collabdesk/permissions.py
+++ b/backend/collabdesk/collabdesk/permissions.py
@@ -284,3 +284,39 @@ class IsEventCreatorOrWorkspaceOwner(permissions.BasePermission):
         return False
 
 
+class IsResourceUploaderOrWorkspaceOwner(permissions.BasePermission):
+    """
+    Permission class for resources that allows:
+    - All authenticated users: Read access (GET, HEAD, OPTIONS)
+    - Resource uploader: Full access (GET, POST, PUT, PATCH, DELETE)
+    - Workspace owner: Full access (GET, POST, PUT, PATCH, DELETE)
+    - Other users: Read-only access
+
+    Usage:
+        Add to permission_classes on resource viewsets that need this behavior.
+    """
+
+    def has_object_permission(self, request, view, obj):
+        """
+        Check if user can perform the action on the resource.
+        """
+        if not request.user or not request.user.is_authenticated:
+            return False
+
+        # Allow read-only access for all authenticated users
+        if request.method in permissions.SAFE_METHODS:
+            return True
+
+        # Check if user is the resource uploader
+        uploaded_by = getattr(obj, 'uploaded_by', None)
+        if uploaded_by and uploaded_by.id == request.user.id:
+            return True
+
+        # Check if user is the workspace owner
+        workspace = getattr(obj, 'workspace', None)
+        if workspace and workspace.created_by_id == request.user.id:
+            return True
+
+        return False
+
+

--- a/backend/collabdesk/events/views.py
+++ b/backend/collabdesk/events/views.py
@@ -6,6 +6,7 @@ from rest_framework.response import Response
 from .serializers import EventSerializer, EventParticipantSerializer
 from .models import Event, EventParticipant
 from collabdesk.middleware import set_workspace_context
+from collabdesk.permissions import IsEventCreatorOrWorkspaceOwner
 from datetime import datetime, timedelta
 from django.utils import timezone
 import logging
@@ -92,7 +93,7 @@ class EventListCreateView(generics.ListCreateAPIView):
 
 class EventDetailView(generics.RetrieveUpdateDestroyAPIView):
     serializer_class = EventSerializer
-    permission_classes = [IsAuthenticated]
+    permission_classes = [IsAuthenticated, IsEventCreatorOrWorkspaceOwner]
 
     def initial(self, request, *args, **kwargs):
         """Override to set workspace context after authentication"""

--- a/backend/collabdesk/messageboard/views.py
+++ b/backend/collabdesk/messageboard/views.py
@@ -5,7 +5,7 @@ from rest_framework.views import APIView
 from rest_framework.exceptions import PermissionDenied
 from .models import Message, Reaction
 from .serializers import MessageSerializer
-from .permissions import IsAuthorOrReadOnly
+from collabdesk.permissions import IsMessageAuthorOrWorkspaceOwnerDelete
 from collabdesk.middleware import set_workspace_context
 import logging
 from django.db.models import Q
@@ -88,7 +88,7 @@ class MessageListCreateView(generics.ListCreateAPIView):
 
 class MessageDetailView(generics.RetrieveUpdateDestroyAPIView):
     serializer_class = MessageSerializer
-    permission_classes = [IsAuthorOrReadOnly]
+    permission_classes = [permissions.IsAuthenticated, IsMessageAuthorOrWorkspaceOwnerDelete]
 
     def initial(self, request, *args, **kwargs):
         """Override to set workspace context after authentication"""

--- a/backend/collabdesk/messageboard/views.py
+++ b/backend/collabdesk/messageboard/views.py
@@ -88,7 +88,10 @@ class MessageListCreateView(generics.ListCreateAPIView):
 
 class MessageDetailView(generics.RetrieveUpdateDestroyAPIView):
     serializer_class = MessageSerializer
-    permission_classes = [permissions.IsAuthenticated, IsMessageAuthorOrWorkspaceOwnerDelete]
+    permission_classes = [
+        permissions.IsAuthenticated,
+        IsMessageAuthorOrWorkspaceOwnerDelete,
+    ]
 
     def initial(self, request, *args, **kwargs):
         """Override to set workspace context after authentication"""

--- a/backend/collabdesk/resources/views.py
+++ b/backend/collabdesk/resources/views.py
@@ -13,6 +13,7 @@ from django.http import FileResponse, Http404, JsonResponse, HttpResponse
 from .serializers import ResourceSerializer
 from .models import Resource
 from collabdesk.middleware import set_workspace_context
+from collabdesk.permissions import IsResourceUploaderOrWorkspaceOwner
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_http_methods
 from .s3_utils import (
@@ -146,7 +147,12 @@ class ResourceCreateView(generics.ListCreateAPIView):
 class ResourceDetailView(generics.RetrieveUpdateDestroyAPIView):
     queryset = Resource.objects.all()
     serializer_class = ResourceSerializer
-    permission_classes = [IsAuthenticated]
+    permission_classes = [IsAuthenticated, IsResourceUploaderOrWorkspaceOwner]
+
+    def initial(self, request, *args, **kwargs):
+        """Override to set workspace context after authentication"""
+        super().initial(request, *args, **kwargs)
+        set_workspace_context(request)
 
     def perform_destroy(self, instance):
         # Delete file from S3 before deleting database record

--- a/backend/collabdesk/workspaces/serializer.py
+++ b/backend/collabdesk/workspaces/serializer.py
@@ -35,7 +35,7 @@ class WorkspaceSerializer(serializers.ModelSerializer):
     members = serializers.SerializerMethodField()
     owner = serializers.SerializerMethodField()
     member_count = serializers.SerializerMethodField()
-    created_by_id = serializers.IntegerField(source='created_by.id', read_only=True)
+    created_by_id = serializers.IntegerField(source="created_by.id", read_only=True)
 
     class Meta:
         model = Workspace

--- a/backend/collabdesk/workspaces/serializer.py
+++ b/backend/collabdesk/workspaces/serializer.py
@@ -35,6 +35,7 @@ class WorkspaceSerializer(serializers.ModelSerializer):
     members = serializers.SerializerMethodField()
     owner = serializers.SerializerMethodField()
     member_count = serializers.SerializerMethodField()
+    created_by_id = serializers.IntegerField(source='created_by.id', read_only=True)
 
     class Meta:
         model = Workspace
@@ -43,6 +44,7 @@ class WorkspaceSerializer(serializers.ModelSerializer):
             "name",
             "description",
             "created_at",
+            "created_by_id",
             "owner",
             "members",
             "member_count",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,7 +16,7 @@ import {
 import { EventDetailsModal } from "./components/modals/EventDetailsModal";
 import { Dashboard } from "./components/dashboard/Dashboard";
 import { Settings } from "./components/settings/Settings";
-import { fetchEvents, setTokenGetter, deleteEvent, fetchCurrentUser, createWorkspace, joinWorkspace, fetchAllUsers, fetchWorkspaceList, type BackendEvent, type User, type RSVPStatus } from "./lib/api";
+import { fetchEvents, setTokenGetter, deleteEvent, fetchCurrentUser, createWorkspace, joinWorkspace, fetchAllUsers, fetchWorkspaceList, fetchWorkspaceInformation, type BackendEvent, type User, type RSVPStatus } from "./lib/api";
 import { parseISO as parseISOBase, addWeeks, isSameWeek, startOfWeek } from "date-fns";
 import Tasks from "./components/tasks/Tasks";
 import { Resources } from "./components/resources/Resources";
@@ -120,6 +120,7 @@ export default function App() {
   const [users, setUsers] = useState<User[]>([]);
   const [userWorkspaces, setUserWorkspaces] = useState<{ workspace_id: string; name: string }[]>([]);
   const [workspacesLoaded, setWorkspacesLoaded] = useState(false);
+  const [isWorkspaceOwner, setIsWorkspaceOwner] = useState(false);
 
   // Fetch user's workspaces
   useEffect(() => {
@@ -231,6 +232,26 @@ export default function App() {
 
     loadCurrentUser();
   }, [isAuthenticated, tokenReady]);
+
+  // Fetch workspace details to determine if current user is the owner
+  useEffect(() => {
+    if (!isAuthenticated || !tokenReady || !workspace || !currentUserId) {
+      setIsWorkspaceOwner(false);
+      return;
+    }
+
+    const checkWorkspaceOwnership = async () => {
+      try {
+        const workspaceDetails = await fetchWorkspaceInformation(workspace, getAccessTokenSilently);
+        setIsWorkspaceOwner(workspaceDetails.created_by_id === currentUserId);
+      } catch (error) {
+        console.error("Failed to fetch workspace details for ownership check:", error);
+        setIsWorkspaceOwner(false);
+      }
+    };
+
+    checkWorkspaceOwnership();
+  }, [isAuthenticated, tokenReady, workspace, currentUserId, getAccessTokenSilently]);
 
   // Calendar state: week start (Sun)
   const [weekStart, setWeekStart] = useState<Date>(() =>
@@ -601,6 +622,7 @@ export default function App() {
                   onClose={() => setSelectedEventForDetails(null)}
                   event={selectedEventForDetails}
                   currentUserId={currentUserId}
+                  isWorkspaceOwner={isWorkspaceOwner}
                   onDelete={handleDeleteEvent}
                   onRsvpChange={refreshEvents}
                   onEventUpdate={handleEventUpdate}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -571,7 +571,7 @@ export default function App() {
               ) : current === "tasks" ? (
                 <Tasks />
               ) : current === "resources" ? (
-                <Resources workspace={workspace} currentUserId={currentUserId} />
+                <Resources workspace={workspace} currentUserId={currentUserId} isWorkspaceOwner={isWorkspaceOwner} />
               ) : current === "message" ? (
                 <MessageBoard openThreadMessageId={openThreadMessageId} />
               ) : current === "chat" ? (

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -573,7 +573,7 @@ export default function App() {
               ) : current === "resources" ? (
                 <Resources workspace={workspace} currentUserId={currentUserId} isWorkspaceOwner={isWorkspaceOwner} />
               ) : current === "message" ? (
-                <MessageBoard openThreadMessageId={openThreadMessageId} />
+                <MessageBoard openThreadMessageId={openThreadMessageId} isWorkspaceOwner={isWorkspaceOwner} />
               ) : current === "chat" ? (
                 <>
                   <header className="mb-6">

--- a/frontend/src/components/dashboard/Dashboard.tsx
+++ b/frontend/src/components/dashboard/Dashboard.tsx
@@ -209,6 +209,7 @@ export function Dashboard({
         onClose={() => setEventModalOpen(false)}
         event={selectedEvent}
         currentUserId={currentUserId}
+        isWorkspaceOwner={currentUserId !== undefined && workspace?.created_by_id === currentUserId}
         onRsvpChange={() => {
           // Optionally refresh events after RSVP change
           console.log("RSVP changed");

--- a/frontend/src/components/messageboard/MessageBoard.tsx
+++ b/frontend/src/components/messageboard/MessageBoard.tsx
@@ -22,7 +22,7 @@ import { ThreadModal } from "./ThreadModal";
 
 // const PAGE_SIZE = 20; 
 
-export function MessageBoard({ openThreadMessageId }: { openThreadMessageId?: string | null }) {
+export function MessageBoard({ openThreadMessageId, isWorkspaceOwner = false }: { openThreadMessageId?: string | null; isWorkspaceOwner?: boolean }) {
   const [messages, setMessages] = useState<Message[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isSending, setIsSending] = useState(false);
@@ -506,6 +506,7 @@ const handleUpdate = async () => {
             onReply={(message) => setThreadMessage(message)}
             currentUser={currentUser}
             userMap={userMap}
+            isWorkspaceOwner={isWorkspaceOwner}
           />
           <div ref={messageEndRef} />
           {showNewMessageIndicator && (

--- a/frontend/src/components/messageboard/MessageFeed.tsx
+++ b/frontend/src/components/messageboard/MessageFeed.tsx
@@ -11,6 +11,7 @@ interface MessageFeedProps {
   onReply?: (message: Message) => void;
   currentUser: { id: string; name: string; email: string };
   userMap: Map<string, string>;
+  isWorkspaceOwner?: boolean;
 }
 
 export function MessageFeed({
@@ -22,6 +23,7 @@ export function MessageFeed({
   onReply,
   currentUser,
   userMap,
+  isWorkspaceOwner = false,
 }: MessageFeedProps) {
   const feedEndRef = useRef<HTMLDivElement>(null);
   const feedContainerRef = useRef<HTMLDivElement>(null);
@@ -82,6 +84,7 @@ export function MessageFeed({
           onReply={onReply}
           currentUser={currentUser}
           userMap={userMap}
+          isWorkspaceOwner={isWorkspaceOwner}
         />
       ))}
       {/* Invisible element to scroll to */}

--- a/frontend/src/components/messageboard/MessageItem.tsx
+++ b/frontend/src/components/messageboard/MessageItem.tsx
@@ -13,6 +13,7 @@ interface MessageItemProps {
   onReply?: (message: Message) => void;
   currentUser: { id: string; name: string; email: string };
   userMap: Map<string, string>;
+  isWorkspaceOwner?: boolean;
 }
 
 export function MessageItem({
@@ -23,6 +24,7 @@ export function MessageItem({
   onReply,
   currentUser,
   userMap,
+  isWorkspaceOwner = false,
 }: MessageItemProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [editContent, setEditContent] = useState(message.content);
@@ -327,48 +329,48 @@ export function MessageItem({
 
               {/* Edit (own messages only) */}
               {isCurrentUser && (
-                <>
-                  <button
-                    onClick={() => setIsEditing(true)}
-                    className="p-1 rounded hover:bg-zinc-200 dark:hover:bg-zinc-800 text-zinc-600 dark:text-zinc-400"
-                    title="Edit message"
+                <button
+                  onClick={() => setIsEditing(true)}
+                  className="p-1 rounded hover:bg-zinc-200 dark:hover:bg-zinc-800 text-zinc-600 dark:text-zinc-400"
+                  title="Edit message"
+                >
+                  <svg
+                    className="w-4 h-4"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
                   >
-                    <svg
-                      className="w-4 h-4"
-                      fill="none"
-                      stroke="currentColor"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth={2}
-                        d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
-                      />
-                    </svg>
-                  </button>
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
+                    />
+                  </svg>
+                </button>
+              )}
 
-                  {/* Delete */}
-                  <button
-                    onClick={() => onDelete(message.id)}
-                    className="p-1 rounded hover:bg-red-100 dark:hover:bg-red-900/20 text-red-600 dark:text-red-400"
-                    title="Delete message"
+              {/* Delete (own messages or workspace owner) */}
+              {(isCurrentUser || isWorkspaceOwner) && (
+                <button
+                  onClick={() => onDelete(message.id)}
+                  className="p-1 rounded hover:bg-red-100 dark:hover:bg-red-900/20 text-red-600 dark:text-red-400"
+                  title="Delete message"
+                >
+                  <svg
+                    className="w-4 h-4"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
                   >
-                    <svg
-                      className="w-4 h-4"
-                      fill="none"
-                      stroke="currentColor"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth={2}
-                        d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
-                      />
-                    </svg>
-                  </button>
-                </>
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                    />
+                  </svg>
+                </button>
               )}
             </div>
           )}

--- a/frontend/src/components/modals/EventDetailsModal.tsx
+++ b/frontend/src/components/modals/EventDetailsModal.tsx
@@ -38,6 +38,7 @@ interface EventDetailsModalProps {
   onClose: () => void;
   event: CalEvent | null;
   currentUserId?: number;
+  isWorkspaceOwner?: boolean;
   onDelete?: (id: string) => void;
   onRsvpChange?: () => void;
   onEventUpdate?: (event: CalEvent) => void;
@@ -48,6 +49,7 @@ export function EventDetailsModal({
   onClose,
   event,
   currentUserId,
+  isWorkspaceOwner = false,
   onDelete,
   onRsvpChange,
   onEventUpdate,
@@ -208,6 +210,7 @@ export function EventDetailsModal({
 
   const isUnavailable = currentEvent.kind === "unavailable";
   const isMyEvent = currentUserId !== undefined && currentEvent.createdBy === currentUserId;
+  const canEditDelete = isMyEvent || isWorkspaceOwner;
   const isAttendee = !isMyEvent && currentUserId !== undefined && currentEvent.attendeesIds?.includes(currentUserId);
   const currentUserUUID = availableUsers.find(u => u.id === currentUserId)?.user_id;
 
@@ -471,7 +474,7 @@ export function EventDetailsModal({
                 </div>
               </div>
 
-              {isMyEvent && (
+              {canEditDelete && (
                 <button
                   onClick={handleEditClick}
                   className="p-1 text-zinc-500 hover:text-indigo-600 dark:text-zinc-400 dark:hover:text-indigo-400 transition-colors"
@@ -543,8 +546,8 @@ export function EventDetailsModal({
               </div>
             </div>
 
-            {/* Attendees - For Event Creator */}
-            {isMyEvent && !isUnavailable && (
+            {/* Attendees - For Event Creator or Workspace Owner */}
+            {canEditDelete && !isUnavailable && (
               <div>
                 <label className="block text-sm font-medium text-zinc-500 dark:text-zinc-400 mb-1">
                   Attendees
@@ -612,8 +615,8 @@ export function EventDetailsModal({
               </div>
             )}
 
-            {/* Attendees - For Non-Creator (Simple List) */}
-            {!isMyEvent && !isUnavailable && (
+            {/* Attendees - For Non-Creator and Non-Owner (Simple List) */}
+            {!canEditDelete && !isUnavailable && (
               <div>
                 <label className="block text-sm font-medium text-zinc-500 dark:text-zinc-400 mb-1">
                   Attendees
@@ -693,8 +696,8 @@ export function EventDetailsModal({
               </div>
             )}
 
-            {/* Delete Button - Only show if user created the event */}
-            {isMyEvent && onDelete && (
+            {/* Delete Button - Only show if user created the event or is workspace owner */}
+            {canEditDelete && onDelete && (
               <div className="pt-4 border-t border-zinc-200 dark:border-zinc-800">
                 <button
                   onClick={() => {

--- a/frontend/src/components/resources/ResourceList.tsx
+++ b/frontend/src/components/resources/ResourceList.tsx
@@ -12,6 +12,7 @@ interface ResourceListProps {
   onDownload: (resource: Resource) => void;
   onDelete: (resource: Resource) => void;
   currentUserId?: number;
+  isWorkspaceOwner?: boolean;
 }
 
 export function ResourceList({
@@ -20,6 +21,7 @@ export function ResourceList({
   onDownload,
   onDelete,
   currentUserId,
+  isWorkspaceOwner = false,
 }: ResourceListProps) {
   if (resources.length === 0) {
     return (
@@ -190,7 +192,7 @@ export function ResourceList({
                       />
                     </svg>
                   </button>
-                  {resource.uploadedById === currentUserId && (
+                  {(resource.uploadedById === currentUserId || isWorkspaceOwner) && (
                     <button
                       onClick={() => onDelete(resource)}
                       className="p-1.5 rounded-md hover:bg-red-50 dark:hover:bg-red-900/20 text-red-600 dark:text-red-400"

--- a/frontend/src/components/resources/Resources.tsx
+++ b/frontend/src/components/resources/Resources.tsx
@@ -12,7 +12,7 @@ import { ResourceUploadModal } from "./ResourceUploadModal";
 import { ResourcePreviewModal } from "./ResourcePreviewModal";
 import { ResourceEditModal } from "./ResourceEditModal";
 
-export function Resources({ workspace, currentUserId }: { workspace: string; currentUserId?: number }) {
+export function Resources({ workspace, currentUserId, isWorkspaceOwner = false }: { workspace: string; currentUserId?: number; isWorkspaceOwner?: boolean }) {
   // State
   const [resources, setResources] = useState<Resource[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -268,6 +268,7 @@ export function Resources({ workspace, currentUserId }: { workspace: string; cur
             onDownload={handleDownload}
             onDelete={handleDelete}
             currentUserId={currentUserId}
+            isWorkspaceOwner={isWorkspaceOwner}
           />
         )}
       </div>


### PR DESCRIPTION
This pull request introduces new, more granular permission classes for workspace-related resources in the backend, and updates the frontend to recognize workspace ownership for conditional UI and action enablement. The changes ensure that only workspace owners (and relevant creators/uploaders) can perform sensitive actions, and that the frontend reflects these permissions in its controls and displays.

**Backend: Enhanced Permissions and Exposure of Ownership**
* New permission classes for object-level and view-level access control:
  - `IsWorkspaceOwner` checks if the user is the owner of a workspace, supporting both object and view level.
  - `IsEventCreatorOrWorkspaceOwner`, `IsResourceUploaderOrWorkspaceOwner`, and `IsMessageAuthorOrWorkspaceOwnerDelete` provide nuanced permissions for events, resources, and messages, respectively, allowing owners or creators/uploaders to perform privileged actions.
* Applied new permissions to relevant views:
  - Events, resources, and messageboard views now use the new permission classes to enforce correct access. [[1]](diffhunk://#diff-dc103144dc9f468585cac9a2e5683e91e0d16c22642f7af7a0ea6e7bc97e0aabR9) [[2]](diffhunk://#diff-dc103144dc9f468585cac9a2e5683e91e0d16c22642f7af7a0ea6e7bc97e0aabL95-R96) [[3]](diffhunk://#diff-af9349e4f1dd23fba9495a7bad815a8eb8adb7e6271d156e53e2e37da7258e13R16) [[4]](diffhunk://#diff-af9349e4f1dd23fba9495a7bad815a8eb8adb7e6271d156e53e2e37da7258e13L149-R155) [[5]](diffhunk://#diff-c28bee3c2cd1201e96393b805296080ee16080f1b8d40c4d9a6595d593a45841L8-R8) [[6]](diffhunk://#diff-c28bee3c2cd1201e96393b805296080ee16080f1b8d40c4d9a6595d593a45841L91-R91)
* The `WorkspaceSerializer` now exposes the `created_by_id` field, allowing the frontend to determine workspace ownership. [[1]](diffhunk://#diff-06f40b35ea144e1ad94c8333036b795b7d7e78a6da633836d72dc600e68e4343R38) [[2]](diffhunk://#diff-06f40b35ea144e1ad94c8333036b795b7d7e78a6da633836d72dc600e68e4343R47)

**Frontend: Workspace Ownership Awareness**
* The app fetches workspace details and determines if the current user is the workspace owner, storing this in `isWorkspaceOwner` state. [[1]](diffhunk://#diff-e56cb91573ddb6a97ecd071925fe26504bb5a65f921dc64c63e534162950e1ebR123) [[2]](diffhunk://#diff-e56cb91573ddb6a97ecd071925fe26504bb5a65f921dc64c63e534162950e1ebR236-R255)
* Ownership information is passed down to resources, message board, and event modals, enabling or disabling actions (like delete) based on ownership. [[1]](diffhunk://#diff-e56cb91573ddb6a97ecd071925fe26504bb5a65f921dc64c63e534162950e1ebL553-R576) [[2]](diffhunk://#diff-e56cb91573ddb6a97ecd071925fe26504bb5a65f921dc64c63e534162950e1ebR625) [[3]](diffhunk://#diff-0da48cf67100d1c4e3ef03d0d0d152a2f611f01c7770752351b5f59a2b764866R212) [[4]](diffhunk://#diff-0b3ba3db155cb28340a96bd5cbfe59cb48be364ba61a1e8238818a31cf38c8fdL25-R25) [[5]](diffhunk://#diff-0b3ba3db155cb28340a96bd5cbfe59cb48be364ba61a1e8238818a31cf38c8fdR509) [[6]](diffhunk://#diff-d4c1c1b9b0c23ee0f5666a0375cfe39f69501f0199b58893d844dd4482dc7ea3R14) [[7]](diffhunk://#diff-d4c1c1b9b0c23ee0f5666a0375cfe39f69501f0199b58893d844dd4482dc7ea3R26) [[8]](diffhunk://#diff-d4c1c1b9b0c23ee0f5666a0375cfe39f69501f0199b58893d844dd4482dc7ea3R87) [[9]](diffhunk://#diff-333ef518dcf3b693f7f4bbca4fc75b0b2a46640ed367d9356f97d46518d76b53R16) [[10]](diffhunk://#diff-333ef518dcf3b693f7f4bbca4fc75b0b2a46640ed367d9356f97d46518d76b53R27) [[11]](diffhunk://#diff-333ef518dcf3b693f7f4bbca4fc75b0b2a46640ed367d9356f97d46518d76b53L330) [[12]](diffhunk://#diff-333ef518dcf3b693f7f4bbca4fc75b0b2a46640ed367d9356f97d46518d76b53R351-R354) [[13]](diffhunk://#diff-333ef518dcf3b693f7f4bbca4fc75b0b2a46640ed367d9356f97d46518d76b53L371) [[14]](diffhunk://#diff-e945890c4ec20b1ec5599e67c66e95a65580708f7923fd9d027e271bb1fd241dR41)

**Summary of Most Important Changes:**

**Backend Permissions and Serialization**
- Added new permission classes (`IsWorkspaceOwner`, `IsEventCreatorOrWorkspaceOwner`, `IsResourceUploaderOrWorkspaceOwner`, `IsMessageAuthorOrWorkspaceOwnerDelete`) for fine-grained access control on workspace-related resources.
- Updated serializers to expose `created_by_id` in `WorkspaceSerializer` for frontend ownership checks. [[1]](diffhunk://#diff-06f40b35ea144e1ad94c8333036b795b7d7e78a6da633836d72dc600e68e4343R38) [[2]](diffhunk://#diff-06f40b35ea144e1ad94c8333036b795b7d7e78a6da633836d72dc600e68e4343R47)
- Applied new permission classes to event, resource, and messageboard views to enforce correct access. [[1]](diffhunk://#diff-dc103144dc9f468585cac9a2e5683e91e0d16c22642f7af7a0ea6e7bc97e0aabR9) [[2]](diffhunk://#diff-dc103144dc9f468585cac9a2e5683e91e0d16c22642f7af7a0ea6e7bc97e0aabL95-R96) [[3]](diffhunk://#diff-af9349e4f1dd23fba9495a7bad815a8eb8adb7e6271d156e53e2e37da7258e13R16) [[4]](diffhunk://#diff-af9349e4f1dd23fba9495a7bad815a8eb8adb7e6271d156e53e2e37da7258e13L149-R155) [[5]](diffhunk://#diff-c28bee3c2cd1201e96393b805296080ee16080f1b8d40c4d9a6595d593a45841L8-R8) [[6]](diffhunk://#diff-c28bee3c2cd1201e96393b805296080ee16080f1b8d40c4d9a6595d593a45841L91-R91)

**Frontend Ownership Awareness and UI Updates**
- Added logic in `App.tsx` to fetch workspace details and determine if the current user is the workspace owner, storing this in state. [[1]](diffhunk://#diff-e56cb91573ddb6a97ecd071925fe26504bb5a65f921dc64c63e534162950e1ebR123) [[2]](diffhunk://#diff-e56cb91573ddb6a97ecd071925fe26504bb5a65f921dc64c63e534162950e1ebR236-R255)
- Propagated `isWorkspaceOwner` to `Resources`, `MessageBoard`, and `EventDetailsModal` components, and updated their child components to enable/disable actions based on ownership. [[1]](diffhunk://#diff-e56cb91573ddb6a97ecd071925fe26504bb5a65f921dc64c63e534162950e1ebL553-R576) [[2]](diffhunk://#diff-e56cb91573ddb6a97ecd071925fe26504bb5a65f921dc64c63e534162950e1ebR625) [[3]](diffhunk://#diff-0da48cf67100d1c4e3ef03d0d0d152a2f611f01c7770752351b5f59a2b764866R212) [[4]](diffhunk://#diff-0b3ba3db155cb28340a96bd5cbfe59cb48be364ba61a1e8238818a31cf38c8fdL25-R25) [[5]](diffhunk://#diff-0b3ba3db155cb28340a96bd5cbfe59cb48be364ba61a1e8238818a31cf38c8fdR509) [[6]](diffhunk://#diff-d4c1c1b9b0c23ee0f5666a0375cfe39f69501f0199b58893d844dd4482dc7ea3R14) [[7]](diffhunk://#diff-d4c1c1b9b0c23ee0f5666a0375cfe39f69501f0199b58893d844dd4482dc7ea3R26) [[8]](diffhunk://#diff-d4c1c1b9b0c23ee0f5666a0375cfe39f69501f0199b58893d844dd4482dc7ea3R87) [[9]](diffhunk://#diff-333ef518dcf3b693f7f4bbca4fc75b0b2a46640ed367d9356f97d46518d76b53R16) [[10]](diffhunk://#diff-333ef518dcf3b693f7f4bbca4fc75b0b2a46640ed367d9356f97d46518d76b53R27) [[11]](diffhunk://#diff-333ef518dcf3b693f7f4bbca4fc75b0b2a46640ed367d9356f97d46518d76b53L330) [[12]](diffhunk://#diff-333ef518dcf3b693f7f4bbca4fc75b0b2a46640ed367d9356f97d46518d76b53R351-R354) [[13]](diffhunk://#diff-333ef518dcf3b693f7f4bbca4fc75b0b2a46640ed367d9356f97d46518d76b53L371) [[14]](diffhunk://#diff-e945890c4ec20b1ec5599e67c66e95a65580708f7923fd9d027e271bb1fd241dR41)